### PR TITLE
fix(config): try filters.tags.only /v.*/ hmmm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,12 +72,16 @@ workflows:
             - install
       - build:
           filters:
+            tags:
+              only: /v.*/
             branches:
               only: master
           requires:
             - test
       - publish:
           filters:
+            tags:
+              only: /v.*/
             branches:
               only: master
           requires:


### PR DESCRIPTION
after merging to master should trigger all jobs, including `build` and `publish`, but the commit after that (which is actually commits and tags from the CI) should only trigger `install` and `test` only, just like as in PR.